### PR TITLE
Remove auto-login after registration

### DIFF
--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -65,10 +65,9 @@ export const AuthProvider = ({ children }) => {
 
   const register = async (email, password, firstName = '', lastName = '') => {
     try {
-      await authAPI.register(email, password, firstName, lastName);
-
-      // After successful registration, automatically log in
-      return await login(email, password);
+      const response = await authAPI.register(email, password, firstName, lastName);
+      debug.log('AuthContext register success:', response);
+      return response;
     } catch (error) {
       console.error('Registration error:', error);
       throw error;


### PR DESCRIPTION
## Purpose
The user requested to change the post-authentication flow: after sign up, users should be redirected to the sign in page instead of being automatically logged in and redirected to the home page. This provides a clearer separation between registration and login processes.

## Code changes
- Removed automatic login call after successful registration in `AuthContext.js`
- Modified the register function to return the registration response directly instead of calling login
- Added debug logging for registration success
- Users will now need to manually sign in after completing registration

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/926fba23ced641ecbfb2f3814bd2b172/mystic-nest)

👀 [Preview Link](https://926fba23ced641ecbfb2f3814bd2b172-mystic-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>926fba23ced641ecbfb2f3814bd2b172</projectId>-->
<!--<branchName>mystic-nest</branchName>-->